### PR TITLE
Add splatter data on newly created cover actor

### DIFF
--- a/scripts/cover.js
+++ b/scripts/cover.js
@@ -209,6 +209,9 @@ async function createActor() {
     hideHealthEstimate: true,
     hideName: false,
   };
+  flags.splatter = {
+    bloodColor: "#000000",
+  };
 
   await actor.update({
     prototypeToken: {


### PR DESCRIPTION
Prevents splatter form making the cover all bloody.